### PR TITLE
Instrument more parts of om.next

### DIFF
--- a/resources/css/plomber.css
+++ b/resources/css/plomber.css
@@ -115,3 +115,73 @@
   font-size: 1em;
   opacity: .5;
 }
+
+.parser-table {
+  -webkit-animation: in-fade-top-soft 500ms;
+  animation: in-fade-top-soft 500ms;
+  background-color: rgba(0, 0, 0, 0.6);
+  font-family: Monaco, monospace;
+  font-size: .75rem;
+  line-height: 2;
+  width: 100%;
+  border-collapse: collapse;
+}
+.parser-table thead,
+.parser-table tr {
+  border-color: none;
+}
+.parser-table th {
+  color: #ffffff;
+  line-height: 1rem;
+  padding: 0.6rem 0;
+/*  text-transform: uppercase;*/
+  text-align: left;
+  border-bottom: 2px solid rgb(127,127,127);
+}
+.parser-table tr:not(:first-child) th {
+  pointer-events: auto;
+  cursor: pointer;
+  padding: 0.8rem 0;
+}
+.parser-table tr:not(:first-child) th:hover span {
+  background-color: rgb(127,127,127);
+  padding: 5px;
+  border-radius: 5px;
+}
+.parser-table tr:not(:first-child) th:first-child,
+.parser-table thead td:first-child {
+  border-right: 2px solid rgb(127,127,127);
+}
+.parser-table th {
+  text-align: center;
+}
+
+.parser-table th,
+.parser-table td {
+  white-space: pre-wrap;
+  text-align: center;
+}
+.parser-table tr th:first-child,
+.parser-table tr td:first-child {
+  padding-left: 1.5rem;
+  width: 20%;
+}
+.parser-table th:not(:first-child),
+.parser-table td:not(:first-child) {
+  width: 5.833333333333%;
+}
+.parser-table tbody tr:nth-child(odd) {
+  background-color: rgba(0, 0, 0, 0.4);
+}
+.parser-table tbody td:first-child {
+  padding-left: 1.5rem;
+}
+.parser-table tfoot td {
+  line-height: 1rem;
+  text-align: center;
+  padding: 1.5rem 0;
+}
+.parser-table small {
+  font-size: 1em;
+  opacity: .5;
+}

--- a/src/devcards/plomber/devcards/core.cljs
+++ b/src/devcards/plomber/devcards/core.cljs
@@ -268,12 +268,15 @@
    (fn []
      (swap! state update-in (conj ref :favorites) inc))})
 
+(defonce plomber-reconciler (plomber/make-reconciler {:toggle-shortcut #{"shift" "ctrl" "a"}}))
+
 (def union-reconciler
   (om/reconciler
     {:state  union-init-data
-     :parser (om/parser {:read union-read :mutate mutate})
+     :parser (om/parser {:read (plomber/instrument-read union-read {:reconciler plomber-reconciler})
+                         :mutate (plomber/instrument-mutate mutate {:reconciler plomber-reconciler})})
      :instrument (plomber/instrument {:extra-fn instrument
-                                      :keymap {:toggle-shortcut #{"shift" "ctrl" "a"}}})}))
+                                      :reconciler plomber-reconciler})}))
 
 (defcard-om-next union
   Dashboard

--- a/src/main/plomber/core.cljs
+++ b/src/main/plomber/core.cljs
@@ -11,6 +11,8 @@
 
 (def ^:private initial-state
   {:measurements nil
+   :query nil
+   :mutate nil
    :sort-key :component-name
    :sort-asc? true})
 
@@ -110,6 +112,29 @@
       (and sort?
            (not sort-asc?)) reverse)))
 
+(defn- generate-parser-stats
+  [{:keys [query mutate]}]
+  (letfn [(stats [s]
+            (reduce
+             (fn [ret [dk samples]]
+               (let [durations (map :duration samples)
+                     cnt (count samples)]
+                 (conj ret {:dispatch-key dk
+                            :count cnt
+                            :min-duration (apply min durations)
+                            :max-duration (apply max durations)
+                            :avg-duration (avg durations)
+                            :std-dev-duration (std-dev durations)}))) [] s))]
+    (cond-> {}
+      query
+      (assoc :query (stats query))
+
+      mutate
+      (assoc :mutate (stats mutate)))))
+
+(def format-ms (partial gstr/format "%.2f ms"))
+(def format-% (partial gstr/format "%.2f %"))
+
 (defui ^:once StatsRow
   Object
   (shouldComponentUpdate [this next-props _]
@@ -125,8 +150,7 @@
                   last-mount-ms avg-render-ms avg-mount-ms max-render-ms
                   max-mount-ms min-render-ms min-mount-ms render-std-dev
                   mount-std-dev]} (om/props this)
-          format-ms (partial gstr/format "%.2f ms")
-          format-% (partial gstr/format "%.2f %")]
+          ]
       (dom/tr nil
         (dom/td nil component-name)
         (dom/td #js {:className "number"} render-count)
@@ -205,10 +229,44 @@
    :min-render-ms "best render time"
    :render-std-dev "render standard deviation"})
 
+(defn- parser-stats-table
+  [label visible? stats sort-key sort-asc?]
+  (dom/table #js {:className "parser-table"
+                  :style #js {:display (if visible? "table" "none")}}
+    (dom/thead nil
+      (dom/tr nil
+        (dom/th #js {:colSpan 6 :className "number"} label))
+      (dom/tr nil
+        (map (fn [[label k]]
+               (dom/th #js {:key label
+                            :onClick #(println "Clicked " label)} (compute-label label (keyword-identical? sort-key k) sort-asc?)))
+             [["Dispatch key" :dispatch-key]
+              ["#" :count]
+              ["Average" :avg-duration]
+              ["Min" :min-duration]
+              ["Max" :max-duration]
+              ["Std. Dev." :std-dev-duration]])))
+    (dom/tbody nil
+               (map-indexed (fn [i item]
+                              (dom/tr nil
+                                (dom/td nil
+                                  (pr-str (:dispatch-key item)))
+                                (dom/td nil
+                                  (:count item 0))
+                                (dom/td nil
+                                  (show-when (:avg-duration item) format-ms))
+                                (dom/td nil
+                                  (show-when (:min-duration item) format-ms))
+                                (dom/td nil
+                                  (show-when (:max-duration item) format-ms))
+                                (dom/td nil
+                                  (show-when (:std-dev-duration item) format-%)))) stats))))
+
+
 (defui ^:once Statistics
   Object
   (initLocalState [this]
-    {:visible? false})
+    {:visible? true})
   (componentDidMount [this]
     (let [{:keys [toggle-shortcut clear-shortcut]} (om/shared this)
           {:keys [visible?]} (om/get-state this)]
@@ -220,6 +278,7 @@
   (render [this]
     (let [{:keys [sort-key sort-asc?] :as props} (om/props this)
           stats (generate-stats props)
+          pstats (generate-parser-stats props)
           {:keys [visible?]} (om/get-state this)
           {:keys [toggle-shortcut clear-shortcut]} (om/shared this)]
       (dom/figure nil
@@ -240,9 +299,13 @@
                   (key->label sort-key)
                   (if sort-asc? "ascending" "descending")
                   (format-shortcut toggle-shortcut)
-                  (format-shortcut clear-shortcut))))))))))
+                  (format-shortcut clear-shortcut))))))
+        (when-let [qstats (:query pstats)]
+          (parser-stats-table "Queries" visible? qstats :dispatch-key true))
+        (when-let [mstats (:mutate pstats)]
+          (parser-stats-table "Mutates" visible? mstats :dispatch-key true))))))
 
-(defn- make-reconciler
+(defn make-reconciler
   ([] (make-reconciler {}))
   ([keymap]
    (let [keymap (merge {:toggle-shortcut #{"ctrl" "shift" "s"}
@@ -262,15 +325,51 @@
     (.insertBefore body node (.-firstChild body))
     node))
 
+(defn instrument-read
+  [pfn {:keys [reconciler]}]
+  (let [state (om/app-state reconciler)]
+    (fn [env k p]
+      (let [st (system-time)
+            r (pfn env k p)
+            et (system-time)]
+        (swap! state update-in [:query k] (fnil conj []) {:dispatch-key k
+                                                          :when st
+                                                          :duration (- et st)
+                                                          :params p
+                                                          :result r})
+        r))))
+
+(defn instrument-mutate
+  [pfn {:keys [reconciler]}]
+  (let [state (om/app-state reconciler)]
+    (fn [env k p]
+      (let [r (pfn env k p)]
+        (if-let [action (:action r)]
+          (assoc r :action (fn []
+                             (let [st (system-time)
+                                   r (action)
+                                   et (system-time)]
+                               (swap! state update-in [:mutate k] (fnil conj []) {:dispatch-key k
+                                                                                  :when st
+                                                                                  :duration (- et st)
+                                                                                  :params p
+                                                                                  :result r})
+                               r)))
+          r)))))
+
 (defn instrument
   ([] (instrument {}))
-  ([{:keys [extra-fn keymap] :or {extra-fn (constantly nil)}}]
+  ([{:keys [extra-fn keymap reconciler] :or {extra-fn (constantly nil)}}]
    (let [class "plomber"
+         classes (atom #{})
          node  (or (gdom/getElementByClass class)
                    (prepend-stats-node class))
-         reconciler (make-reconciler keymap)]
+         reconciler (or reconciler
+                        (make-reconciler keymap))]
      (om/add-root! reconciler Statistics node)
      (fn [{:keys [props children class factory] :as m}]
        (extra-fn m)
-       (wrap-lifecycle-methods (om/app-state reconciler) class)
+       (when-not (@classes class)
+         (swap! classes conj class)
+         (wrap-lifecycle-methods (om/app-state reconciler) class))
        (apply factory props children)))))

--- a/src/main/plomber/core.cljs
+++ b/src/main/plomber/core.cljs
@@ -289,7 +289,7 @@
 (defui ^:once Statistics
   Object
   (initLocalState [this]
-    {:visible? true})
+    {:visible? false})
   (componentDidMount [this]
     (let [{:keys [toggle-shortcut clear-shortcut]} (om/shared this)
           {:keys [visible?]} (om/get-state this)]


### PR DESCRIPTION
This adds support for instrumenting parser reads/mutates as well as the send fn.